### PR TITLE
remove softfork info from properties after active for 3 months

### DIFF
--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -299,6 +299,10 @@ fn sidecar(config: &Mapping, addr: &str) -> Result<(), Box<dyn Error>> {
                             timeout,
                             since,
                         } => {
+                            // stop showing soft fork info when it's been active for ~12 weeks
+                            if info.blocks >= since + 12096 {
+                                continue;
+                            }
                             let start_time_pretty = human_readable_timestamp(start_time);
                             let end_time_pretty = human_readable_timestamp(timeout);
                             ("Active", start_time_pretty, end_time_pretty, since)


### PR DESCRIPTION
Removes info from properties for soft forks that have been active for more than 3 months.

This means that taproot info will disappear from properties at block 721728, or about 1108 blocks (7-8 days) from the time of writing (current block: 720620)