### PR TITLE
recover from 22.0.0 migration bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION_CORE := "22.0"
-VERSION_S9 := "22.0.0"
+VERSION_S9 := "22.0.1"
 MANAGER_SRC := $(shell find ./manager -name '*.rs') manager/Cargo.toml manager/Cargo.lock
 
 .DELETE_ON_ERROR:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,10 +1,8 @@
 id: bitcoind
 title: "Bitcoin Core"
-version: 22.0.0
+version: 22.0.1
 release-notes: |
-  * Update to Bitcoin Core v22.0
-  * Add `blockfilterindex` and `peerblockfilters` config options
-  * allow user to specify ports on manully added peers
+  * Fix migration bug in 22.0.0
 license: mit
 wrapper-repo: https://github.com/Start9Labs/bitcoind-wrapper
 upstream-repo: https://github.com/bitcoin/bitcoin
@@ -190,12 +188,32 @@ migrations:
       mounts:
         main: /root/.bitcoin
       inject: false
+    "=22.0.0":
+      type: docker
+      image: main
+      system: false
+      entrypoint: /usr/local/bin/migrations/eq_22_0_0.sh
+      args: ["from"]
+      io-format: json
+      mounts:
+        main: /root/.bitcoin
+      inject: false
   to:
     "<22.0.0":
       type: docker
       image: main
       system: false
       entrypoint: /usr/local/bin/migrations/lt_22_0_0.sh
+      args: ["to"]
+      io-format: json
+      mounts:
+        main: /root/.bitcoin
+      inject: false
+    "=22.0.0":
+      type: docker
+      image: main
+      system: false
+      entrypoint: /usr/local/bin/migrations/eq_22_0_0.sh
       args: ["to"]
       io-format: json
       mounts:

--- a/migrations/eq_22_0_0.sh
+++ b/migrations/eq_22_0_0.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ea
+
+if [ $1 = "from" ]; then 
+    yq -i '.advanced.peers.addnode |= map(select(.hostname != ~))' /root/.bitcoin/start9/config.yaml
+    echo '{"configured": true }'
+    exit 0
+elif [ $1 = "to" ]; then
+    echo '{"configured": true }'
+    exit 0
+else
+    echo "FATAL: Invalid argument: {from, to}. Migration failed." >&2
+    exit 1
+fi

--- a/migrations/lt_22_0_0.sh
+++ b/migrations/lt_22_0_0.sh
@@ -3,7 +3,7 @@
 set -ea
 
 if [ $1 = "from" ]; then 
-    yq -i '.advanced.peers.addnode |= map({"hostname": ., "port": ~})' /root/.bitcoin/start9/config.yaml
+    yq -i '.advanced.peers.addnode.[] |= {"hostname":., "port":~}' /root/.bitcoin/start9/config.yaml
     yq -i '(.advanced.blockfilters.blockfilterindex, .advanced.blockfilters.peerblockfilters) = false' /root/.bitcoin/start9/config.yaml
     echo '{"configured": true }'
     exit 0

--- a/migrations/lt_22_0_0.sh
+++ b/migrations/lt_22_0_0.sh
@@ -3,6 +3,7 @@
 set -ea
 
 if [ $1 = "from" ]; then 
+    yq -i '.advanced.peers.addnode |= map(select(.hostname != ~ or . == "*"))' /root/.bitcoin/start9/config.yaml
     yq -i '.advanced.peers.addnode.[] |= {"hostname":., "port":~}' /root/.bitcoin/start9/config.yaml
     yq -i '(.advanced.blockfilters.blockfilterindex, .advanced.blockfilters.peerblockfilters) = false' /root/.bitcoin/start9/config.yaml
     echo '{"configured": true }'


### PR DESCRIPTION
Version 22.0.0 had a bad config migration, which updated empty lists (`addnode: []`) to lists containing one invalid object (`addnode: [{port: ~}]`). The migration is supposed to convert a list of strings to a list of objects. The object must contain the key `hostname` or it is considered invalid. For some reason some invocations of the `yq` `map` function apparently insert [invalid] objects even when mapping empty lists.

This new release fixes invalid configs resulting from the application of the broken migration, and also performs the migration.