### PR TITLE
Update/v30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ RUN . /tmp/bdb_prefix.sh && \
   -DBUILD_DAEMON=ON \
   -DENABLE_HARDENING=ON \
   -DREDUCE_EXPORTS=ON \
-  -DWITH_ZMQ=ON
+  -DWITH_ZMQ=ON \
+  -DENABLE_IPC=OFF
 RUN cmake --build build -j$(nproc)
 RUN cmake --install build
 RUN strip ${BITCOIN_PREFIX}/bin/*

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,10 +1,9 @@
 id: bitcoind
 title: "Bitcoin Core"
-version: 29.2.0
+version: 30.0.0
 eos-version: 0.3.4.4
 release-notes: |
-  * Update Bitcoin to [v29.2](https://github.com/bitcoin/bitcoin/releases/tag/v29.2)
-  * IBD performance optimizations
+  * Update Bitcoin to [v30.0](https://github.com/bitcoin/bitcoin/releases/tag/v30.0)
 license: MIT
 wrapper-repo: https://github.com/Start9Labs/bitcoind-startos
 upstream-repo: https://github.com/bitcoin/bitcoin

--- a/scripts/services/action.ts
+++ b/scripts/services/action.ts
@@ -62,7 +62,7 @@ export const action = {
     _input?: T.Config,
   ): Promise<T.ResultType<T.ActionResult>> {
     const coinstatsinfoLocation = {
-      path: "indexes/coinstats",
+      path: "/indexes/coinstatsindex/",
       volumeId: "main",
     };
     if (await util.exists(effect, coinstatsinfoLocation) === false) {

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -234,7 +234,7 @@ export const getConfig: T.ExpectedExports.getConfig = async (effects) => {
               range: "[0,100000]",
               integral: true,
               units: "bytes",
-              default: 83,
+              default: 100_000,
             },
           },
         },

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -460,7 +460,9 @@ export const migration: T.ExpectedExports.migration =
               if (
                 config.blkconstr.datacarriersize === 42
               ) {
-                config.blkconstr.datacarriersize = 100_000;
+                config.advanced.mempool.datacarriersize = 100_000;
+              } else {
+                config.advanced.mempool.datacarriersize = config.blkconstr.datacarriersize
               }
             }
             return config;

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -444,10 +444,23 @@ export const migration: T.ExpectedExports.migration =
                 .test(config)
             ) {
               if (
-                config.advanced.mempool.datacarriersize === 83 ||
-                config.advanced.mempool.datacarriersize === 42
+                config.advanced.mempool.datacarriersize === 83
               ) {
                 config.advanced.mempool.datacarriersize = 100_000;
+              }
+            } else if (
+              matches
+                .shape({
+                  blkconstr: matches.shape({
+                    datacarriersize: matches.any,
+                  }),
+                })
+                .test(config)
+            ) {
+              if (
+                config.blkconstr.datacarriersize === 42
+              ) {
+                config.blkconstr.datacarriersize = 100_000;
               }
             }
             return config;

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -452,7 +452,7 @@ export const migration: T.ExpectedExports.migration =
             }
             return config;
           },
-          true,
+          false,
           {
             version: "30.0.0",
             type: "up",
@@ -477,7 +477,7 @@ export const migration: T.ExpectedExports.migration =
             }
             return config;
           },
-          true,
+          false,
           {
             version: "30.0.0",
             type: "down",

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -429,6 +429,61 @@ export const migration: T.ExpectedExports.migration =
           type: "down",
         }),
       },
+      "30.0.0": {
+        up: compat.migrations.updateConfig(
+          (config) => {
+            if (
+              matches
+                .shape({
+                  advanced: matches.shape({
+                    mempool: matches.shape({
+                      datacarriersize: matches.any,
+                    }),
+                  }),
+                })
+                .test(config)
+            ) {
+              if (
+                config.advanced.mempool.datacarriersize === 83 ||
+                config.advanced.mempool.datacarriersize === 42
+              ) {
+                config.advanced.mempool.datacarriersize = 100_000;
+              }
+            }
+            return config;
+          },
+          true,
+          {
+            version: "30.0.0",
+            type: "up",
+          }
+        ),
+        down: compat.migrations.updateConfig(
+          (config: any) => {
+            if (
+              matches
+                .shape({
+                  advanced: matches.shape({
+                    mempool: matches.shape({
+                      datacarriersize: matches.any,
+                    }),
+                  }),
+                })
+                .test(config)
+            ) {
+              if (config.advanced.mempool.datacarriersize === 100_000) {
+                config.advanced.mempool.datacarriersize = 83;
+              }
+            }
+            return config;
+          },
+          true,
+          {
+            version: "30.0.0",
+            type: "down",
+          }
+        ),
+      },
     },
-    "29.2.0"
+    "30.0.0"
   );


### PR DESCRIPTION
- Update to Core v30
- Update default `datacarriersize` to 100,000
- On `up` migrate `datacarriersize` to 100,00 if the current value is the previous default for Core (83) or the Knots default (42).
- On `down` migrate `datacarriersize` to 83 if the current value is the v30 default (100,000)
- Update path for coinstats index to `/indexes/coinstatsindex/` for `delete-coinstatsindex` action to match the new location as of v30.