### PR TITLE
chore: startos sdk beta.47  (for update/040-29.2)

### DIFF
--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     paths-ignore: ['*.md']
-    branches: ['main', 'master', 'update/040']
+    branches: ['main', 'master', 'update/040', 'update/040-29.2']
   push:
     paths-ignore: ['*.md']
-    branches: ['main', 'master', 'update/040']
+    branches: ['main', 'master', 'update/040', 'update/040-29.2']
 
 jobs:
   build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,16 +6,14 @@
     "": {
       "name": "bitcoin-core",
       "dependencies": {
-        "@start9labs/start-sdk": "^0.4.0-beta.45",
-        "@types/js-yaml": "^4.0.5",
-        "diskusage": "^1.2.0",
-        "js-yaml": "^4.1.0"
+        "@start9labs/start-sdk": "^0.4.0-beta.47",
+        "diskusage": "^1.2.0"
       },
       "devDependencies": {
-        "@types/node": "^20.11.30",
-        "@vercel/ncc": "^0.38.1",
-        "prettier": "^3.2.5",
-        "typescript": "^5.4.3"
+        "@types/node": "^22.19.6",
+        "@vercel/ncc": "^0.38.4",
+        "prettier": "^3.7.4",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@iarna/toml": {
@@ -52,9 +50,9 @@
       }
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "0.4.0-beta.45",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-0.4.0-beta.45.tgz",
-      "integrity": "sha512-N4iIifr5f1ElB4zcZnW8hCkPOAsfCxf+1UGqp249Tzm+gIRj45aq1wiE+vGCeSyGIuHsfMp3h5Pouyvfn33FOQ==",
+      "version": "0.4.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-0.4.0-beta.47.tgz",
+      "integrity": "sha512-GhnKJ8F/aEuW4gu0GxHXcSDrj69+H+Dysr0a743q7Hy2HZQSvndAy0B3cPmqz+0oaHKXnCL5r8nicgH8zXlENw==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -75,37 +73,25 @@
       "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
       "license": "MIT"
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
-      "version": "20.17.46",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.46.tgz",
-      "integrity": "sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw==",
+      "version": "22.19.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.6.tgz",
+      "integrity": "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.38.3",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.3.tgz",
-      "integrity": "sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==",
+      "version": "0.38.4",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
+      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
     },
     "node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
@@ -150,18 +136,6 @@
       "dependencies": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mime": {
@@ -215,9 +189,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -243,9 +217,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -257,9 +231,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -6,16 +6,14 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "^0.4.0-beta.45",
-    "@types/js-yaml": "^4.0.5",
-    "diskusage": "^1.2.0",
-    "js-yaml": "^4.1.0"
+    "@start9labs/start-sdk": "^0.4.0-beta.47",
+    "diskusage": "^1.2.0"
   },
   "devDependencies": {
-    "@types/node": "^20.11.30",
-    "@vercel/ncc": "^0.38.1",
-    "prettier": "^3.2.5",
-    "typescript": "^5.4.3"
+    "@types/node": "^22.19.6",
+    "@vercel/ncc": "^0.38.4",
+    "prettier": "^3.7.4",
+    "typescript": "^5.9.3"
   },
   "prettier": {
     "trailingComma": "all",

--- a/startos/fileModels/bitcoin.conf.ts
+++ b/startos/fileModels/bitcoin.conf.ts
@@ -1,5 +1,6 @@
 import { FileHelper, matches } from '@start9labs/start-sdk'
 import { bitcoinConfDefaults } from '../utils'
+import { sdk } from '../sdk'
 
 const { anyOf, arrayOf, object } = matches
 
@@ -154,7 +155,7 @@ function onWrite(a: unknown): any {
 
 export const bitcoinConfFile = FileHelper.ini(
   {
-    volumeId: 'main',
+    base: sdk.volumes.main,
     subpath: '/bitcoin.conf',
   },
   shape,

--- a/startos/fileModels/store.json.ts
+++ b/startos/fileModels/store.json.ts
@@ -1,4 +1,5 @@
 import { FileHelper, matches } from '@start9labs/start-sdk'
+import { sdk } from '../sdk'
 
 const { object, boolean } = matches
 
@@ -11,7 +12,7 @@ export const shape = object({
 
 export const storeJson = FileHelper.json(
   {
-    volumeId: 'main',
+    base: sdk.volumes.main,
     subpath: '/store.json',
   },
   shape,

--- a/startos/install/versions/index.ts
+++ b/startos/install/versions/index.ts
@@ -1,3 +1,3 @@
-export { v29_2_0_2 as coreCurrent} from './v29_2_0_2-beta.4'
+export { v29_2_0_2 as coreCurrent} from './v29_2_0_2'
 
 export const other = []

--- a/startos/install/versions/v29_2_0_2.ts
+++ b/startos/install/versions/v29_2_0_2.ts
@@ -7,7 +7,7 @@ import { mainMounts } from '../../main'
 const { whitebind, bind } = bitcoinConfDefaults
 
 export const v29_2_0_2 = VersionInfo.of({
-  version: '29.2:2-beta.4',
+  version: '29.2:2-beta.5',
   releaseNotes: 'Revamped for StartOS 0.4.0',
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
- update file models to use 'sdk.volumes.main'
- bump package.json dependencies
- bump versions