### PR TITLE
fix: whitelisted p2p listener for bridge-side dependents (28.4:17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Settings **not** managed by StartOS (hardcoded):
 | Setting         | Value                | Reason                                                                                                              |
 | --------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `rpccookiefile` | `.cookie`            | Fixed RPC authentication                                                                                            |
-| `whitebind`     | `0.0.0.0:8333`       | Required for peer connections                                                                                       |
-| `bind`          | `0.0.0.0:58333`      | Internal peer listening port                                                                                        |
+| `whitebind`     | `0.0.0.0:58334`      | Whitelisted p2p listener, reachable only over the LXC bridge (the `peer-local` host)                                |
+| `bind`          | `0.0.0.0:58333`      | Public p2p listener; the `peer` binding maps the host's 8333 onto it                                                |
 | `listen`        | `1`                  | Always accepting connections                                                                                        |
 | `assumevalid`   | Hardcoded block hash | Performance optimization                                                                                            |
 | `-onion`        | `10.0.3.1:9050`      | Tor SOCKS on the internal bridge (resolved at startup; always set — harmless connection-refused when Tor is absent) |
@@ -137,6 +137,8 @@ This is transparent to dependent services — port 8332 always serves RPC.
 | ZeroMQ      | 28332 | TCP      | Block notifications (rawblock, hashblock)           | When ZMQ enabled                           |
 | ZeroMQ      | 28333 | TCP      | Transaction notifications (rawtx, hashtx, sequence) | When ZMQ enabled                           |
 | I2P Console | 7070  | HTTP     | I2P daemon web console                              | When embedded I2P enabled with web console |
+
+A further binding, `peer-local`, publishes bitcoind's whitelisted p2p listener (container port 58334) on the LXC bridge alone. It exports no interface, so it never reaches the LAN or the internet. A dependent that fetches blocks over p2p resolves it with `sdk.host.getBridgeAddress({ hostId: peerLocalHostId, internalPort: peerPortLocal })` and connects with `noban` + `download` permissions — exempt from inbound eviction and from the historical-block upload limit. The public `peer` binding grants neither, because anonymous inbound peers arrive on it.
 
 ## Actions (StartOS UI)
 
@@ -219,7 +221,7 @@ Notifications accompany every consequential outcome (verdicts cleared, tips skip
 
 | Property           | Value                                                                    |
 | ------------------ | ------------------------------------------------------------------------ |
-| Version constraint | `>= 0.4.9.5`                                                             |
+| Version constraint | Declared in `startos/dependencies.ts`                                    |
 | Required state     | Running                                                                  |
 | Health checks      | None                                                                     |
 | Mounted volumes    | None                                                                     |
@@ -283,7 +285,7 @@ Where our permanent default overrides upstream (e.g. `rpcthreads`, `rpcworkqueue
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions and development workflow.
+Build and development workflow follow the StartOS packaging guide: <https://docs.start9.com/packaging>. Keep `README.md`, `instructions.md`, and `AGENTS.md` in sync with any change to user-visible behavior or package structure.
 
 ---
 
@@ -303,6 +305,7 @@ volumes:
 ports:
   rpc: 8332
   peer: 8333
+  peer-local: 58334 (bridge only, no exported interface)
   zmq-block: 28332 (conditional)
   zmq-tx: 28333 (conditional)
   i2p-console: 7070 (conditional)

--- a/startos/fileModels/bitcoin.conf.ts
+++ b/startos/fileModels/bitcoin.conf.ts
@@ -5,8 +5,8 @@ import { i18n } from '../i18n'
 import { sdk } from '../sdk'
 import {
   i2PSamAddress,
-  peerPortExternal,
   peerPortInternal,
+  peerPortLocal,
   rpcallowip,
   rpcallowipPruned,
   rpcbind,
@@ -65,8 +65,8 @@ export const shape = z.object({
     .literal(`0.0.0.0:${peerPortInternal}`)
     .catch(`0.0.0.0:${peerPortInternal}`),
   whitebind: z
-    .literal(`0.0.0.0:${peerPortExternal}`)
-    .catch(`0.0.0.0:${peerPortExternal}`),
+    .literal(`0.0.0.0:${peerPortLocal}`)
+    .catch(`0.0.0.0:${peerPortLocal}`),
   // Mempool enforced
   mempoolfullrbf: z.undefined().optional().catch(undefined),
 
@@ -648,7 +648,7 @@ function formToFile(
     rpccookiefile: '.cookie',
     listen: true,
     bind: `0.0.0.0:${peerPortInternal}`,
-    whitebind: `0.0.0.0:${peerPortExternal}`,
+    whitebind: `0.0.0.0:${peerPortLocal}`,
     rpcauth: raw?.rpcauth?.filter((a) => !!a) as string[] | undefined,
     whitelist: raw?.whitelist?.filter((a) => !!a) as string[] | undefined,
     externalip: raw?.externalip?.filter((a) => !!a) as string[] | undefined,

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -6,8 +6,10 @@ import {
   i2pUiPort,
   peerHostId,
   peerInterfaceId,
+  peerLocalHostId,
   peerPortExternal,
   peerPortInternal,
+  peerPortLocal,
   rpcHostId,
   rpcInterfaceId,
   rpcPort,
@@ -69,6 +71,19 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
   const peerReceipt = await peerMultiOrigin.export([peer])
 
   receipts.push(peerReceipt)
+
+  // Whitelisted p2p for services on the bridge. bitcoind whitebinds this port,
+  // so a peer arriving on it gets noban + download + mempool — which a
+  // dependent that pulls historical blocks needs to avoid inbound eviction and
+  // the upload-target cutoff. No exported interface: an unexported binding
+  // stays off the LAN and lands only on lo/lxcbr0, so a public peer can't reach
+  // the permissions and keeps arriving on `peer`'s plain `bind`.
+  await sdk.MultiHost.of(effects, peerLocalHostId).bindPort(peerPortLocal, {
+    protocol: null,
+    preferredExternalPort: peerPortLocal,
+    addSsl: null,
+    secure: { ssl: false },
+  })
 
   // ZMQ (conditional). Block (28332) and transaction (28333) are exposed as
   // separate interfaces so a dependent (e.g. LND) can resolve each one's bridge

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -73,8 +73,8 @@ export const main = sdk.setupMain(async ({ effects }) => {
 
   const { reindexBlockchain, reindexChainstate } = store
 
-  // Tor SOCKS over the bridge. The mapped value only changes when the address
-  // itself does — with the 9050 fallback it stays constant across tor
+  // Tor SOCKS over the bridge. The bridge address only changes when tor's
+  // binding does — with the 9050 fallback it stays constant across tor
   // install/update/uninstall, so this .const() never restarts Bitcoin unless
   // tor lands on a different port (then one healing restart). A dead bridge
   // address is just connection-refused, so -onion is always safe to pass.

--- a/startos/utils.ts
+++ b/startos/utils.ts
@@ -7,6 +7,18 @@ export const peerHostId = 'peer'
 export const zmqHostId = 'zmq'
 export const i2pConsoleHostId = 'i2p-console'
 
+/**
+ * The whitelisted p2p listener, for services on the LXC bridge. Bound without
+ * an exported interface, so it is reachable only over the bridge — a dependent
+ * resolves it with `sdk.host.getBridgeAddress({ hostId: peerLocalHostId,
+ * internalPort: peerPortLocal })`.
+ *
+ * A dependent that fetches blocks over p2p (electrs, NBXplorer) must use this
+ * host rather than `peerHostId`: the latter maps onto the plain `bind`, where
+ * it lands with no permissions alongside public inbound peers.
+ */
+export const peerLocalHostId = 'peer-local'
+
 // Interface ids (the exported service interfaces on the hosts above).
 export const rpcInterfaceId = 'rpc'
 export const peerInterfaceId = 'peer'
@@ -16,8 +28,12 @@ export const zmqTxInterfaceId = 'zmq-tx'
 export const zmqPortBlock = 28332
 export const zmqPortTransaction = 28333
 
+/** Host-side port the public `peer` binding prefers — the canonical p2p port. */
 export const peerPortExternal = 8333
+/** Container port bitcoind plain-binds (`bind`); the `peer` binding maps here. */
 export const peerPortInternal = 58333
+/** Container port bitcoind whitelists (`whitebind`); the `peer-local` binding maps here. */
+export const peerPortLocal = 58334
 
 export const rpcPort = 8332
 export const rpcPortPruned = 58332

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,23 +1,23 @@
 import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '28.4:16',
+  version: '28.4:17',
   releaseNotes: {
-    en_US: `Resolves the addresses of connected services more reliably.
+    en_US: `Gives local services a dedicated, trusted connection for downloading blocks.
 
-Bitcoin Core looked up where to reach its dependencies through a field that only applies to one of the two ways a service can publish a port. It now reads the address itself, so a dependency changing how it serves TLS can no longer leave Bitcoin Core unable to find it. Nothing changes in normal operation.`,
-    es_ES: `Resuelve de forma más fiable las direcciones de los servicios conectados.
+Services on this server that pull blocks from Bitcoin Core over the peer protocol — Electrs, for instance — were connecting on the same port as anonymous peers from the internet, and were treated with the same suspicion: liable to be dropped to make room for another peer, and subject to the limits that protect your upload bandwidth. They now connect on a separate, local-only port that Bitcoin Core trusts, so a busy wallet query can no longer get them disconnected. Connections from the internet are unaffected and still arrive on the public port.`,
+    es_ES: `Ofrece a los servicios locales una conexión dedicada y de confianza para descargar bloques.
 
-Bitcoin Core localizaba sus dependencias mediante un campo que solo se aplica a una de las dos formas en que un servicio puede publicar un puerto. Ahora lee la dirección en sí, de modo que si una dependencia cambia su forma de servir TLS, Bitcoin Core seguirá encontrándola. En funcionamiento normal no cambia nada.`,
-    de_DE: `Ermittelt die Adressen verbundener Dienste zuverlässiger.
+Los servicios de este servidor que obtienen bloques de Bitcoin Core mediante el protocolo entre pares —Electrs, por ejemplo— se conectaban por el mismo puerto que los pares anónimos de internet y recibían el mismo trato receloso: podían ser desconectados para dejar sitio a otro par y estaban sujetos a los límites que protegen tu ancho de banda de subida. Ahora se conectan por un puerto aparte, solo local, en el que Bitcoin Core confía, de modo que una consulta intensa de una cartera ya no puede provocar su desconexión. Las conexiones desde internet no cambian y siguen llegando al puerto público.`,
+    de_DE: `Gibt lokalen Diensten eine eigene, vertrauenswürdige Verbindung zum Herunterladen von Blöcken.
 
-Bitcoin Core suchte seine Abhängigkeiten über ein Feld, das nur für eine der beiden Arten gilt, auf die ein Dienst einen Port veröffentlichen kann. Jetzt wird die Adresse selbst gelesen, sodass eine Abhängigkeit, die ihre TLS-Bereitstellung ändert, für Bitcoin Core auffindbar bleibt. Im normalen Betrieb ändert sich nichts.`,
-    pl_PL: `Pewniej ustala adresy połączonych usług.
+Dienste auf diesem Server, die Blöcke über das Peer-Protokoll von Bitcoin Core beziehen — etwa Electrs —, verbanden sich über denselben Port wie anonyme Gegenstellen aus dem Internet und wurden ebenso misstrauisch behandelt: Sie konnten getrennt werden, um Platz für eine andere Gegenstelle zu schaffen, und unterlagen den Limits, die deine Upload-Bandbreite schützen. Jetzt verbinden sie sich über einen separaten, rein lokalen Port, dem Bitcoin Core vertraut, sodass eine intensive Wallet-Abfrage sie nicht mehr trennen kann. Verbindungen aus dem Internet bleiben unverändert und laufen weiterhin über den öffentlichen Port.`,
+    pl_PL: `Daje lokalnym usługom dedykowane, zaufane połączenie do pobierania bloków.
 
-Bitcoin Core wyszukiwał swoje zależności przez pole, które dotyczy tylko jednego z dwóch sposobów publikowania portu przez usługę. Teraz odczytuje sam adres, więc zależność zmieniająca sposób udostępniania TLS nadal pozostanie odnajdywalna dla Bitcoin Core. W normalnej pracy nic się nie zmienia.`,
-    fr_FR: `Détermine plus fiablement les adresses des services connectés.
+Usługi na tym serwerze, które pobierają bloki z Bitcoin Core przez protokół peer-to-peer — na przykład Electrs — łączyły się tym samym portem co anonimowe węzły z internetu i były traktowane równie nieufnie: mogły zostać rozłączone, by zrobić miejsce innemu węzłowi, i podlegały limitom chroniącym twoje pasmo wysyłania. Teraz łączą się osobnym, wyłącznie lokalnym portem, któremu Bitcoin Core ufa, więc intensywne zapytanie portfela nie może już ich rozłączyć. Połączenia z internetu nie zmieniają się i nadal trafiają na port publiczny.`,
+    fr_FR: `Donne aux services locaux une connexion dédiée et de confiance pour télécharger les blocs.
 
-Bitcoin Core localisait ses dépendances via un champ qui ne s'applique qu'à l'un des deux modes de publication d'un port par un service. Il lit désormais l'adresse elle-même : une dépendance qui change sa façon de servir TLS reste donc trouvable par Bitcoin Core. Rien ne change en fonctionnement normal.`,
+Les services de ce serveur qui récupèrent des blocs auprès de Bitcoin Core via le protocole pair-à-pair — Electrs, par exemple — se connectaient sur le même port que les pairs anonymes d'internet et étaient traités avec la même méfiance : susceptibles d'être déconnectés pour laisser la place à un autre pair, et soumis aux limites qui protègent votre bande passante montante. Ils se connectent désormais sur un port distinct, uniquement local, auquel Bitcoin Core fait confiance, de sorte qu'une requête de portefeuille intensive ne peut plus provoquer leur déconnexion. Les connexions venues d'internet sont inchangées et arrivent toujours sur le port public.`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Problem

Retiring `.startos` DNS left bitcoind's `whitebind` listener orphaned. Every internal dependent now resolves a bridge address, and the only peer binding maps onto the plain `bind` — the listener anonymous inbound peers share. A dependent that pulls blocks over p2p therefore connects with no permissions at all.

Confirmed on a live node, before:

```
subver: /electrs:0.11.1/   addrbind: 10.0.3.226:58333   permissions: []
```

The whitelisted listener had zero peers — nothing had reached it since the DNS retirement.

Without `noban`/`download` that connection is liable to inbound eviction and to the `maxuploadtarget` cutoff on historical blocks. electrs exits when its p2p link drops and never reconnects, so one drop is a restart — and under a client that queries it hard (Canary polls unsubscribed scripthashes every 60s) a restart loop.

## Change

Add a `peer-local` host: a bridge-only binding onto the whitebind listener, following tor's SOCKS pattern — no exported interface, so it lands on `lo`/`lxcbr0` only and a public peer can never reach the permissions. Public peers keep arriving on `peer` → plain `bind`, unchanged.

The whitebind listener moves to its own port, `58334`, so `peerPortExternal` carries a single meaning again (the host-side port the public binding prefers). Nothing reached the old one.

`28.x` is the baseline line every dependent's `versionRange` is written against, so `>=28.4:17` becomes the floor for a dependent needing the new host.

After:

```
subver: /electrs:0.11.1/   addrbind: 10.0.3.47:58334   permissions: [noban, relay, mempool, download, addr]
```

## Dependents

electrs and btcpayserver (NBXplorer) are the only two dependents that resolve bitcoind's peer host. Both move to `peer-local` and gate on `>=28.4:17`. The other 11 bitcoind dependents reach it over RPC/ZMQ only and are unaffected — their ranges stay at `>=28.4:14`.

**Merge this before the electrs and btcpayserver PRs** — they pin `bitcoin-core-startos#next/28.x` and won't compile until that ref carries `peerLocalHostId`/`peerPortLocal`.

## Test plan

1. Install this build over an existing bitcoind.
2. Confirm the config repaired itself — `start-cli package attach bitcoind -n bitcoind -- grep -E 'bind|white' /root/.bitcoin/bitcoin.conf` → `bind=0.0.0.0:58333`, `whitebind=0.0.0.0:58334`.
3. Install electrs `0.11.1:14` and check `daemon_p2p_addr` resolves the new host — `start-cli package attach electrs -n electrs -- cat /data/electrs.toml`.
4. Confirm the peer is whitelisted:
   `start-cli package attach bitcoind -n bitcoind -- bitcoin-cli -rpccookiefile=/root/.bitcoin/.cookie getpeerinfo | jq '.[]|select(.subver|test("electrs"))|{addrbind,permissions}'`
   → `addrbind` ends `:58334` and `permissions` contains `noban` + `download`.
5. Confirm public peering is unchanged: inbound clearnet/Tor peers still land on `:58333` with `permissions: []`, and the peer interface is still reachable on 8333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)