### PR TITLE
Fix the UTXO snapshot download (assumeutxo)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,8 @@ ENV BITCOIN_DATA=/root/.bitcoin
 ENV BITCOIN_PREFIX=/opt/bitcoin
 ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
 
+# curl is load-bearing: the assumeutxo action shells out to it in this image
+# to download the UTXO snapshot.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates curl e2fsprogs jq tini yq && \

--- a/instructions.md
+++ b/instructions.md
@@ -70,7 +70,7 @@ Caveats that apply during an actual split:
 
 ### Other actions
 
-- **Download UTXO Snapshot (assumeutxo)** — fast-sync from a recent UTXO snapshot; available while running, hidden once fully synced.
+- **Download UTXO Snapshot (assumeutxo)** — fast-sync from a recent UTXO snapshot; available while running, hidden once fully synced. The URL must be a direct link to a `.dat` snapshot file, which can be one you serve from your own machine over the LAN.
 - **Runtime Information** — connection count, block height, sync progress, and soft-fork status.
 
 ## Limitations

--- a/startos/actions/assumeutxo.ts
+++ b/startos/actions/assumeutxo.ts
@@ -21,8 +21,15 @@ const assumeutxoInputSpec = sdk.InputSpec.of({
     name: i18n('UTXO Snapshot URL'),
     description: i18n('URL of UTXO Snapshot to bootstrap bitcoin'),
     required: true,
-    default: null, // @TODO update to start9 hosted and placeholder
-    // @TODO add pattern for url ending in .dat
+    default: null, // @TODO default to a Start9-hosted snapshot once one exists
+    placeholder: 'https://example.com/utxo-840000.dat',
+    inputmode: 'url',
+    patterns: [
+      {
+        regex: '^https?://\\S+\\.dat(\\?\\S*)?$',
+        description: i18n('Must be an http(s) URL ending in .dat'),
+      },
+    ],
   }),
 })
 
@@ -81,21 +88,42 @@ export const assumeutxo = sdk.Action.withInput(
     )
 
     assumeutxoPromise = (async () => {
-      const conf = (await bitcoinConfFile.read().once())!
+      const rootfs = await assumeutxoSubc.rootfs
 
       try {
-        const rootfs = await assumeutxoSubc.rootfs
+        const conf = (await bitcoinConfFile.read().once())!
         await fs.mkdir(`${rootfs}/tmp/snap`, { recursive: true })
         await fs.rm(`${rootfs}${snapshotTempFile}`, {
           force: true,
         })
 
+        // No overall timeout — a full snapshot legitimately takes hours — so
+        // the speed floor is what bounds a wedged transfer.
         await assumeutxoSubc.execFail(
-          ['curl', '-fsSL', '-o', snapshotTempFile, input.snapshotUrl.trim()],
+          [
+            'curl',
+            '-fsSL',
+            '--connect-timeout',
+            '30',
+            '--speed-limit',
+            '1024',
+            '--speed-time',
+            '120',
+            '--retry',
+            '5',
+            '--retry-delay',
+            '10',
+            '--continue-at',
+            '-',
+            '-o',
+            snapshotTempFile,
+            input.snapshotUrl.trim(),
+          ],
           {},
           null,
         )
 
+        const headersDeadline = Date.now() + 6 * 60 * 60 * 1000
         do {
           const getBlockHeaderRes = await assumeutxoSubc.exec([
             ...bitcoinCliArgs({ prune: !!conf.prune }),
@@ -103,6 +131,10 @@ export const assumeutxo = sdk.Action.withInput(
             block_840_000,
           ])
           if (getBlockHeaderRes.exitCode !== 0) {
+            if (Date.now() > headersDeadline)
+              throw new Error(
+                `headers never reached the snapshot height: ${String(getBlockHeaderRes.stderr)}`,
+              )
             await new Promise((resolve) => setTimeout(resolve, 10_000))
             continue
           }
@@ -123,9 +155,19 @@ export const assumeutxo = sdk.Action.withInput(
       } catch (e) {
         console.log('Error downloading snapshot:\n', e)
         await sdk.action.createOwnTask(effects, assumeutxo, 'important', {
-          reason: 'Previous attempt to download Snapshot failed.',
+          reason: i18n(
+            'Previous attempt to download Snapshot failed: ${error}',
+            {
+              error: e instanceof Error ? e.message : String(e),
+            },
+          ),
         })
       } finally {
+        // loadtxoutset consumes the snapshot, and a failed attempt re-downloads
+        // from scratch, so nothing here is worth the disk it occupies.
+        await fs
+          .rm(`${rootfs}/tmp/snap`, { recursive: true, force: true })
+          .catch(console.error)
         await assumeutxoSubc.destroy()
         assumeutxoSubc = null
         assumeutxoPromise = null

--- a/startos/actions/assumeutxo.ts
+++ b/startos/actions/assumeutxo.ts
@@ -91,7 +91,7 @@ export const assumeutxo = sdk.Action.withInput(
         })
 
         await assumeutxoSubc.execFail(
-          ['wget', '-O', snapshotTempFile, input.snapshotUrl.trim()],
+          ['curl', '-fsSL', '-o', snapshotTempFile, input.snapshotUrl.trim()],
           {},
           null,
         )

--- a/startos/i18n/dictionaries/default.ts
+++ b/startos/i18n/dictionaries/default.ts
@@ -99,6 +99,8 @@ const dict = {
   'Download in progress...': 1005,
   'Snapshot in use': 1006,
   'Snapshot download in progress. Upon successful download the snapshot will be loaded as the active chainstate and any blocks between the snapshot blockheight and tip will be downloaded and verified. Blocks from genesis to the snapshot blockheight will continue to be verfied in the background. Once the IBD catches up to the snapshot height the chain will have been fully validated': 1007,
+  'Must be an http(s) URL ending in .dat': 1008,
+  'Previous attempt to download Snapshot failed: ${error}': 1009,
 
   // actions/runtimeInfo.ts
   'Runtime Information': 1100,

--- a/startos/i18n/dictionaries/translations.ts
+++ b/startos/i18n/dictionaries/translations.ts
@@ -100,6 +100,8 @@ export default {
     1005: 'Descarga en progreso...',
     1006: 'Instantánea en uso',
     1007: 'Descarga de instantánea en progreso. Tras una descarga exitosa, la instantánea se cargará como el chainstate activo y se descargarán y verificarán los bloques entre la altura de bloque de la instantánea y la punta. Los bloques desde génesis hasta la altura de bloque de la instantánea continuarán verificándose en segundo plano. Una vez que el IBD alcance la altura de la instantánea, la cadena habrá sido completamente validada',
+    1008: 'Debe ser una URL http(s) que termine en .dat',
+    1009: 'El intento anterior de descargar la instantánea falló: ${error}',
 
     // actions/runtimeInfo.ts
     1100: 'Información de tiempo de ejecución',
@@ -377,6 +379,8 @@ export default {
     1005: 'Download läuft...',
     1006: 'Snapshot in Verwendung',
     1007: 'Snapshot-Download läuft. Nach erfolgreichem Download wird der Snapshot als aktiver Chainstate geladen und Blöcke zwischen der Snapshot-Blockhöhe und der Spitze werden heruntergeladen und verifiziert. Blöcke von Genesis bis zur Snapshot-Blockhöhe werden weiterhin im Hintergrund verifiziert. Sobald die IBD die Snapshot-Höhe erreicht, wurde die Kette vollständig validiert',
+    1008: 'Muss eine http(s)-URL sein, die auf .dat endet',
+    1009: 'Der vorherige Versuch, den Snapshot herunterzuladen, ist fehlgeschlagen: ${error}',
 
     // actions/runtimeInfo.ts
     1100: 'Laufzeitinformationen',
@@ -654,6 +658,8 @@ export default {
     1005: 'Pobieranie w toku...',
     1006: 'Migawka w użyciu',
     1007: 'Pobieranie migawki w toku. Po pomyślnym pobraniu migawka zostanie załadowana jako aktywny chainstate, a bloki między wysokością bloku migawki a szczytem zostaną pobrane i zweryfikowane. Bloki od genezy do wysokości bloku migawki będą nadal weryfikowane w tle. Gdy IBD dogoni wysokość migawki, łańcuch zostanie w pełni zwalidowany',
+    1008: 'Musi być adresem URL http(s) kończącym się na .dat',
+    1009: 'Poprzednia próba pobrania migawki nie powiodła się: ${error}',
 
     // actions/runtimeInfo.ts
     1100: 'Informacje o czasie wykonywania',
@@ -931,6 +937,8 @@ export default {
     1005: 'Téléchargement en cours...',
     1006: "Instantané en cours d'utilisation",
     1007: "Téléchargement d'instantané en cours. Après un téléchargement réussi, l'instantané sera chargé en tant que chainstate actif et les blocs entre la hauteur de bloc de l'instantané et le sommet seront téléchargés et vérifiés. Les blocs de la genèse à la hauteur de bloc de l'instantané continueront d'\u00eatre vérifiés en arrière-plan. Une fois que l'IBD rattrape la hauteur de l'instantané, la chaîne aura été entièrement validée",
+    1008: 'Doit être une URL http(s) se terminant par .dat',
+    1009: "La tentative précédente de téléchargement de l'instantané a échoué : ${error}",
 
     // actions/runtimeInfo.ts
     1100: "Informations d'exécution",


### PR DESCRIPTION
## Problem

**Download UTXO Snapshot (assumeutxo)** has failed for every user since the runtime image moved to Debian:

```
ExitError: wget failed with exit code 2: Filesystem I/O Error: No such file or directory (os error 2)
```

That reads like a bad URL or a missing directory, and is neither. `wget` is not installed in the runtime image, so `execve` fails with `ENOENT` and `start-container` surfaces its own `ErrorKind::Filesystem` — both the message and the exit code come from StartOS, not from wget.

The action has shelled out to `wget` since it was added. That worked only because the final stage was `alpine`, where `/usr/bin/wget` is a busybox applet. `NN.x:10` switched the final stage to `debian:stable-slim`, which has no busybox and does not install wget; nothing referenced it at build time to catch the break.

## Fix

Download with `curl`, which the runtime image does install.

- `-f` — an HTTP error status fails the download instead of saving the error page as the snapshot (wget's default; curl's is not).
- `-L` — follow redirects (likewise).
- `-sS` — no progress meter, errors still shown. The runtime accumulates a subprocess's whole stderr in memory, and this download runs for hours.

The Dockerfile now records that curl is load-bearing, so a future trim of the package list doesn't quietly break the action the same way.

No version bump — this rides on the revision being cut in #251.

## Also in this PR

Four adjacent failures in the same action, all of which end with it stuck or the node worse off:

- **A wedged transfer hung forever.** There is no overall timeout — a full snapshot legitimately takes hours — so a speed floor bounds a transfer that has stopped moving without capping one that is merely slow. `--retry` with `--continue-at` resumes rather than restarting 11 GB. (Note these have to be separate argv elements: curl rejects `--connect-timeout=30`.)
- **The wait for headers to reach the snapshot height never ended,** so a stopped bitcoind pinned the action at "Download in progress…" until the service restarted. It now gives up after six hours, and every call that can throw is inside the `try` — the `bitcoin.conf` read was outside it, and escaped the promise the same way — so the promise always clears.
- **The snapshot was never deleted.** `loadtxoutset` consumes it and a failed attempt re-downloads from scratch, so it is ~11 GB of dead weight in the data volume either way; removing it in `finally` covers both outcomes.
- **The failure task said only that the attempt failed,** sending anyone diagnosing it to the logs — which is what the missing-`wget` bug cost. It now carries the error.

Also fills the input spec's two TODOs: a placeholder, `inputmode: 'url'`, and a pattern requiring a direct `.dat` link. The Start9-hosted default has nothing to point at yet, so that TODO stays.

## Test plan

1. Install the s9pk on a node that is **not** fully synced (the action hides itself once sync completes).
2. Start the service and run **Download UTXO Snapshot (assumeutxo)** with a snapshot URL, e.g. `https://files-vps02.jaonoctus.dev/utxo-840000.dat`.
3. The action returns "Snapshot download in progress" and raises no failure task; `/media/startos/data/package-data/volumes/bitcoind/data/main/tmp/snap/snapshot` grows toward the full snapshot size.
4. Once headers pass block 840,000 the package runs `loadtxoutset`; `bitcoin-cli getchainstates` then shows the snapshot chainstate, and the node serves the tip while background validation continues. `…/main/tmp/snap/` is gone once it returns — the ~11 GB is reclaimed.
5. Negative case: run it against a URL that 404s. It fails promptly, no HTML error page is left as `snapshot`, `…/main/tmp/snap/` is cleaned up, and the task now reads "Previous attempt to download Snapshot failed: curl failed with exit code 22: …".
6. Input validation: a URL not ending in `.dat` is rejected by the form before the action runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
