### PR TITLE
refactor: drop the RDTS re-validation half of chain-split recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ The Dockerfile fetches the upstream Bitcoin Core release tarball from `bitcoinco
 
 Three additional containers are used:
 
-| Container | Image                              | Purpose                                       |
-| --------- | ---------------------------------- | --------------------------------------------- |
+| Container | Image                                     | Purpose                                       |
+| --------- | ----------------------------------------- | --------------------------------------------- |
 | `proxy`   | `ghcr.io/start9labs/btc-rpc-proxy:v0.5.0` | RPC proxy for pruned nodes                    |
-| `python`  | `python` (Alpine)                  | Runs `rpcauth.py` to generate RPC credentials |
-| `i2pd`    | `purplei2p/i2pd`                   | Embedded I2P daemon (when enabled)            |
+| `python`  | `python` (Alpine)                         | Runs `rpcauth.py` to generate RPC credentials |
+| `i2pd`    | `purplei2p/i2pd`                          | Embedded I2P daemon (when enabled)            |
 
 ## Volume and Data Layout
 
@@ -64,9 +64,9 @@ Three additional containers are used:
 
 StartOS-specific files on the `main` volume:
 
-| File         | Purpose                                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `store.json` | Persistent StartOS state (reindex flags, sync status, chain-recovery flags and the `rdtsEnforcedLastRun` enforcement marker) |
+| File         | Purpose                                                                                                                         |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `store.json` | Persistent StartOS state (reindex flags, sync status, the chain-recovery flag and the `rdtsEnforcedLastRun` enforcement marker) |
 
 Blockchain data directories (`blocks/`, `chainstate/`, `indexes/`) reside on the `main` volume alongside the standard `bitcoin.conf` and `.cookie` files.
 
@@ -192,11 +192,10 @@ A further binding, `peer-local`, publishes bitcoind's whitelisted p2p listener (
 
 bitcoind persists a validity verdict for every block it has evaluated (`CBlockIndex::nStatus` in `blocks/index/`) and trusts those verdicts verbatim on startup — they are never re-derived, and they don't record _which_ consensus rules produced them. Because all `bitcoind` flavors share one datadir, a flavor switch changes the rules without changing the verdicts. Around a BIP-110 (RDTS) chain split, arriving here from the RDTS-enforcing [Bitcoin Knots](https://github.com/Start9Labs/bitcoin-knots-startos) flavor would otherwise leave RDTS-driven `BLOCK_FAILED_VALID` marks in place and pin this node off the chain it considers best.
 
-Bitcoin Core never enforces RDTS, so this package carries only the non-enforcing half of the recovery machinery (`startos/forkRecovery.ts` + the `chain-recovery` oneshot in `startos/main.ts`; the enforcing half — the RDTS-range replay — lives in the Bitcoin Knots RDTS flavor):
+The enforcing half of that problem needs no package code at all — the Knots release the RDTS flavor pins re-validates the RDTS-applicable range itself when it starts on a datadir that advanced without enforcement. Bitcoin Core never enforces RDTS, so this package carries only the non-enforcing half (`startos/forkRecovery.ts` + the `chain-recovery` oneshot in `startos/main.ts`):
 
 - **A durable enforcement marker.** `store.json` records `rdtsEnforcedLastRun`; this flavor writes `false` each start. A `true` value left by the RDTS-enforcing flavor — or an unknown marker, i.e. a legacy datadir last advanced by a package version that predates it — is treated as an enforcement-regime transition: it materializes the `reconsiderInvalidTips` flag (a free no-op when there are no invalid tips) (before the marker is updated, so a crash between the writes re-detects rather than loses the transition). Cross-flavor migrations (on the Knots side) set the same flag deterministically at switch time as a belt-and-suspenders path.
 - **The remedy.** `reconsiderInvalidTips` — `getchaintips` → `reconsiderblock` every `invalid` tip. Clears the verdict on the block, its ancestors, and descendants (persisted); reconnection re-validates fully, so genuinely-invalid branches re-flag themselves. Idempotent and a no-op when there are no invalid tips. Tips whose fork point lies below `pruneheight` are skipped (reorganizing onto them would hit a fatal disconnect on pruned data) and reported in a warning notification pointing at **Reindex Blockchain** (a full re-download on pruned nodes).
-- **A dormant flag.** `revalidateFromRdts` exists in this flavor's store shape but is never consumed here: it is carried so a flavor switch never strips a pending flag from the shared store, and the RDTS-enforcing flavor consumes it to replay the RDTS-applicable range on its first start.
 
 Notifications accompany every consequential outcome (verdicts cleared, tips skipped on a pruned node, recovery failed). Peering is the one thing the package cannot fix: after verdicts are corrected the node still needs peers serving the intended chain, which the user docs call out.
 

--- a/startos/fileModels/store.json.ts
+++ b/startos/fileModels/store.json.ts
@@ -8,25 +8,15 @@ export const shape = z
     /** Set when leaving the RDTS-enforcing flavor: on next start, clear
      *  persisted invalid-block verdicts on chain tips (reconsiderblock).
      *  Present in every bitcoind flavor's shape so a flavor switch never
-     *  strips a pending flag from the shared store. */
+     *  strips a pending flag from the shared store — this shape `.strip()`s
+     *  keys it doesn't declare. */
     reconsiderInvalidTips: z.boolean().catch(false),
-    /** Set when entering/activating RDTS enforcement on a datadir that may
-     *  have advanced under non-enforcing rules: on next start, re-validate
-     *  the RDTS-applicable block range (invalidateblock+reconsiderblock).
-     *  Present in every flavor's shape; only the RDTS flavor consumes it. */
-    revalidateFromRdts: z.boolean().catch(false),
-    /** Warning-dedup marker for the requires-reindex outcome of RDTS
-     *  re-validation: set once the "cannot replay in place" warning has been
-     *  posted so it is not re-posted every start while the condition persists;
-     *  cleared when re-validation resolves (not-applicable / revalidated).
-     *  Only the RDTS-enforcing flavor writes it. */
-    rdtsReindexWarned: z.boolean().catch(false),
     /** Whether the binary that last advanced this datadir enforced the RDTS
      *  consensus rules — the package-level durable marker bitcoind itself
      *  lacks (its persisted block verdicts don't record which rules
-     *  produced them). Every flavor records it each start; a transition
-     *  materializes the recovery flag above (undefined = legacy datadir,
-     *  treated as unknown → re-validate when enforcement is on). */
+     *  produced them). Every flavor records it each start; the non-enforcing
+     *  flavors read it to recognize inherited RDTS verdicts as foreign
+     *  (undefined = legacy datadir, treated as unknown → reconsider). */
     rdtsEnforcedLastRun: z.boolean().optional().catch(undefined),
     fullySynced: z.boolean().catch(false),
     snapshotInUse: z.boolean().catch(false),

--- a/startos/forkRecovery.ts
+++ b/startos/forkRecovery.ts
@@ -1,8 +1,8 @@
 import { GetBlockchainInfo, bitcoinCliArgs } from './utils'
 
 /**
- * Chain-split recovery for the shared `bitcoind` datadir. This module is
- * byte-identical in every bitcoind flavor's repo; only the callers differ.
+ * Chain-split recovery for the shared `bitcoind` datadir. Shared across every
+ * bitcoind flavor's repo — keep the copies in sync; only the callers differ.
  *
  * All bitcoind flavors (Bitcoin Core, Bitcoin Knots pre-RDTS, Bitcoin Knots
  * RDTS) share one package id and one data volume, so a flavor switch carries
@@ -11,24 +11,21 @@ import { GetBlockchainInfo, bitcoinCliArgs } from './utils'
  * binary. Those verdicts are trusted verbatim on startup — bitcoind never
  * re-validates buried blocks under the new binary's rules, and the persisted
  * validity level does not record which consensus rules produced it. Around a
- * contentious BIP-110 (RDTS) chain split that inheritance makes the node
- * follow the wrong chain in both directions:
+ * contentious BIP-110 (RDTS) chain split that inheritance would make the node
+ * follow the wrong chain in both directions. The two directions are fixed in
+ * different places:
  *
  * - Leaving enforcement (switching to Core / pre-RDTS Knots): RDTS-driven
  *   BLOCK_FAILED_VALID marks persist, so the non-enforcing flavor refuses
- *   the most-work chain it would otherwise follow. Remedy: `reconsiderblock`
- *   each invalid chain tip (reconsiderInvalidTips).
+ *   the most-work chain it would otherwise follow. The destination binary
+ *   knows nothing about RDTS and cannot recognize those verdicts as foreign,
+ *   so the package clears them: `reconsiderblock` each invalid chain tip
+ *   (reconsiderInvalidTips), run by the flavor being switched *to*.
  * - Entering enforcement (switching to RDTS Knots, or a package update that
  *   moves the pin from a pre-RDTS to an RDTS release): blocks connected
  *   while enforcement was off are cache-valid and never re-checked against
- *   RDTS — the publicly disclosed BIP-110 late-upgrade validation gap.
- *   Remedy: disconnect and replay
- *   every block from the first RDTS-applicable height under the now-active
- *   rules (revalidateAgainstRdts). All three RDTS rule classes re-run on
- *   reconnect: mandatory signaling and the output-size limit are re-checked
- *   in ConnectBlock unconditionally, and script rules re-run because the
- *   enforcing release's default assumevalid point (height 912,683 in
- *   v29.3.knots20260508) is far below the RDTS-applicable range.
+ *   RDTS. Knots ≥ 29.4 re-validates the RDTS-applicable range itself at
+ *   startup, so the package does nothing here.
  *
  * Enforcement model: whether a node enforces RDTS is a property of the
  * running *binary*, not of configuration. The RDTS-enforcing flavor pins an
@@ -37,15 +34,18 @@ import { GetBlockchainInfo, bitcoinCliArgs } from './utils'
  * start regardless of `consensusrules` — that option records user consent
  * (and silences an hourly warning), it does not gate enforcement. Bitcoin
  * Core and pre-RDTS Knots binaries never enforce. Callers therefore derive
- * enforcement from the node itself via getRdtsDeployment (never-enforcing
+ * enforcement from the node itself via isRdtsEnforcing (never-enforcing
  * flavors may hardcode false), and every flavor's main.ts records it in the
  * `rdtsEnforcedLastRun` store marker each start, treating a change as a
- * switch between enforcement regimes.
+ * switch between enforcement regimes. That marker is what tells the
+ * *non*-enforcing flavors that the verdicts they inherited are foreign, so
+ * every flavor must keep writing it — including the enforcing one, which
+ * never acts on it itself.
  *
- * Both remedies are safe no-ops when there is nothing to fix, and both
- * self-heal: a reconsidered block that is still invalid under the running
- * rules is simply re-marked invalid when its reconnection is attempted, and
- * the node settles on the best remaining valid chain.
+ * The remedy is a safe no-op when there is nothing to fix, and self-heals: a
+ * reconsidered block that is still invalid under the running rules is simply
+ * re-marked invalid when its reconnection is attempted, and the node settles
+ * on the best remaining valid chain.
  */
 
 /** A container that can run bitcoin-cli against the live bitcoind. */
@@ -57,45 +57,10 @@ export type CliRunner = {
   }>
 }
 
-/**
- * First height at which any BIP-110 (RDTS) rule can apply to a block on
- * mainnet: the start of the mandatory-signaling interval,
- * max_activation_height (965,664) − 2 × signaling window (2,016) = 961,632.
- * Anchoring re-validation here covers the whole mandatory-signaling
- * interval (961,632–963,647) and every possible ACTIVE range: from the
- * deployment's current mainnet state (STARTED below the window), the
- * earliest reachable activation height equals the window start.
- * rdtsAnchorHeight() additionally derives the anchor from the running
- * node's own deployment parameters and uses whichever is lowest, so a
- * hypothetical earlier activation can only widen the re-validated range.
- *
- * Must match the consensus params of the Knots release pinned by the
- * RDTS-enforcing flavor (verified against v29.3.knots20260508). When that
- * flavor bumps its pinned release, re-verify these params and that its
- * defaultAssumeValid stays below this height.
- */
-export const RDTS_FIRST_APPLICABLE_HEIGHT = 961_632
-
-export type RdtsDeployment = {
-  type: string
-  /** First height at which the rules are enforced (present once active). */
-  height?: number
-  active: boolean
-  bip9?: {
-    start_time: number
-    min_activation_height?: number
-    max_activation_height?: number
-    status: string
-    since: number
-    status_next?: string
-    statistics?: { period: number }
-  }
-}
-
 export type GetDeploymentInfo = {
   hash: string
   height: number
-  deployments: Record<string, RdtsDeployment | undefined>
+  deployments: Record<string, unknown>
 }
 
 export type ChainTip = {
@@ -109,18 +74,6 @@ export type ChainTip = {
     | 'valid-headers'
     | 'valid-fork'
     | 'unknown'
-}
-
-export type ChainState = {
-  blocks: number
-  bestblockhash: string
-  snapshot_blockhash?: string
-  validated: boolean
-}
-
-export type GetChainStates = {
-  headers: number
-  chainstates: ChainState[]
 }
 
 const cli = async (
@@ -159,38 +112,16 @@ const cliJson = async <T>(
  * signal for the RDTS build and does NOT depend on `consensusrules` (that
  * option records consent and silences a warning; it does not gate
  * enforcement). Never-enforcing flavors MUST hardcode false — they cannot
- * derive it. Keying on presence, never `dep.active`, is deliberate: a fresh
- * RDTS-flavor install before "Activate RDTS" is acknowledged still enforces
- * and must read as such.
+ * derive it. Keying on presence, never the deployment's `active` field, is
+ * deliberate: a fresh RDTS-flavor install before "Activate RDTS" is
+ * acknowledged still enforces and must read as such.
  */
-export async function getRdtsDeployment(
+export async function isRdtsEnforcing(
   subc: CliRunner,
   opts: { prune: boolean },
-): Promise<RdtsDeployment | undefined> {
+): Promise<boolean> {
   const info = await cliJson<GetDeploymentInfo>(subc, opts, 'getdeploymentinfo')
-  return info.deployments['reduced_data']
-}
-
-/**
- * The height to anchor RDTS re-validation at: the lowest of the hardcoded
- * mandatory-signaling start, the same figure derived entirely from the
- * node's own deployment params (max_activation_height − 2 × signaling
- * window; both must come from the node — mixing a node-reported
- * max_activation with a hardcoded window is only coincidentally right on
- * mainnet), and the node-reported first enforced height (present once the
- * deployment is active). Lower anchors only widen the replay; the result
- * is floored at 1 so a pathological params combination can never produce
- * an unusable height.
- */
-export function rdtsAnchorHeight(dep: RdtsDeployment | undefined): number {
-  const candidates = [RDTS_FIRST_APPLICABLE_HEIGHT]
-  const max = dep?.bip9?.max_activation_height
-  const period = dep?.bip9?.statistics?.period
-  if (typeof max === 'number' && typeof period === 'number') {
-    candidates.push(max - 2 * period)
-  }
-  if (typeof dep?.height === 'number') candidates.push(dep.height)
-  return Math.max(1, Math.min(...candidates))
+  return info.deployments['reduced_data'] !== undefined
 }
 
 export type ReconsiderResult = {
@@ -259,181 +190,5 @@ export async function reconsiderInvalidTips(
     }
     await cli(subc, opts, 'reconsiderblock', tip.hash)
     result.reconsidered.push(tip)
-  }
-}
-
-export type RevalidateResult =
-  /** Chain has not reached the RDTS-applicable range: every applicable block
-   *  will be validated under the active rules as it connects, so there is
-   *  nothing to re-validate. */
-  | { outcome: 'not-applicable'; blocks: number }
-  /** The applicable range cannot be replayed locally (data pruned away, or
-   *  the chainstate rests on an assumeutxo snapshot that is not yet fully
-   *  validated). Only a full reindex — a chain re-download on pruned
-   *  nodes — re-validates it. */
-  | { outcome: 'requires-reindex'; reason: 'pruned' | 'assumeutxo' }
-  /** The range was disconnected and replayed under the active RDTS rules. */
-  | {
-      outcome: 'revalidated'
-      fromHeight: number
-      tipBefore: string
-      tipAfter: string
-    }
-
-/**
- * Re-validate every block from `anchorHeight` (see rdtsAnchorHeight) under
- * the now-active RDTS rules: `invalidateblock` the block at that height
- * (rolls the chain back to its parent), then `reconsiderblock` it (clears
- * the failure flags and lets ActivateBestChain reconnect the whole range
- * through ConnectBlock, where all BIP-110 checks live). Any block that
- * violates RDTS is re-marked invalid during the replay and the node settles
- * on the best RDTS-valid chain — whether the divergence is at the anchor
- * height or later.
- *
- * The invalidate→reconsider pair is idempotent and interruption-safe: if
- * stopped between the two calls the node is left parked below the anchor
- * with the old chain still marked invalid. The below-anchor gate therefore
- * distinguishes that parked state from a chain that never reached the
- * range: any invalid branch extending to or past the anchor is reconsidered
- * (its reconnection under the active rules IS the re-validation) before
- * `not-applicable` can be returned.
- *
- * Pruning guard: disconnecting [anchor, tip] requires block and undo data
- * down to the anchor. bitcoind has no such pre-check of its own — an
- * invalidateblock into pruned data silently stops at the prune horizon,
- * reporting success while leaving a partial rollback — so callers must
- * never reach that state: when pruneheight > anchor this returns
- * `requires-reindex` without touching anything, and the rollback is
- * re-verified after invalidateblock in case pruning advanced past the
- * anchor between the gate check and the call (partial rollbacks are healed
- * with a reconsiderblock before falling back to reindex). Same for a
- * not-yet-validated assumeutxo chainstate, which lacks undo data at and
- * below its snapshot base.
- */
-export async function revalidateAgainstRdts(
-  subc: CliRunner,
-  opts: { prune: boolean },
-  anchorHeight: number,
-  /** Invoked once all gates pass and the (possibly long) replay is about to
-   *  begin — the hook for a user-facing "started" notification. */
-  onReplayStart?: () => Promise<void>,
-): Promise<RevalidateResult> {
-  const info = await cliJson<GetBlockchainInfo>(subc, opts, 'getblockchaininfo')
-  if (info.blocks < anchorHeight) {
-    // Distinguish "never reached the range" from "parked below the anchor
-    // by an interrupted invalidate→reconsider pair": recover any invalid
-    // branch reaching into the RDTS range before declaring nothing to do.
-    // Tips and chain info are re-fetched every iteration for the same
-    // reason reconsiderInvalidTips does: each reconsiderblock can reorg
-    // the chain and advance the prune horizon, invalidating earlier
-    // fork-point math.
-    const attempted = new Set<string>()
-    let sawParked = false
-    let reconsidered = 0
-    let replayStarted = false
-    while (true) {
-      const tips = await cliJson<ChainTip[]>(subc, opts, 'getchaintips')
-      const tip = tips.find(
-        (t) =>
-          t.status === 'invalid' &&
-          t.height >= anchorHeight &&
-          !attempted.has(t.hash),
-      )
-      if (!tip) break
-      sawParked = true
-      attempted.add(tip.hash)
-
-      const cur = await cliJson<GetBlockchainInfo>(
-        subc,
-        opts,
-        'getblockchaininfo',
-      )
-      const forkHeight = tip.height - tip.branchlen
-      // Parked recovery is a pure forward connect of [anchor, tip] (the fork
-      // point is anchor-1, so nothing is disconnected); it only needs block
-      // data from forkHeight+1 up. Skip only when that block is pruned —
-      // `> forkHeight + 1`, not `> forkHeight`, so the pruneheight == anchor
-      // boundary is not over-skipped into a spurious critical reindex task.
-      if (cur.pruned && (cur.pruneheight ?? 0) > forkHeight + 1) continue
-      if (!replayStarted) {
-        replayStarted = true
-        await onReplayStart?.()
-      }
-      await cli(subc, opts, 'reconsiderblock', tip.hash)
-      reconsidered++
-    }
-    if (!sawParked) {
-      return { outcome: 'not-applicable', blocks: info.blocks }
-    }
-    if (!reconsidered) return { outcome: 'requires-reindex', reason: 'pruned' }
-    const healed = await cliJson<GetBlockchainInfo>(
-      subc,
-      opts,
-      'getblockchaininfo',
-    )
-    return {
-      outcome: 'revalidated',
-      fromHeight: anchorHeight,
-      tipBefore: info.bestblockhash,
-      tipAfter: healed.bestblockhash,
-    }
-  }
-  const states = await cliJson<GetChainStates>(subc, opts, 'getchainstates')
-  if (states.chainstates.some((c) => c.snapshot_blockhash && !c.validated)) {
-    return { outcome: 'requires-reindex', reason: 'assumeutxo' }
-  }
-  if (info.pruned && (info.pruneheight ?? 0) > anchorHeight) {
-    return { outcome: 'requires-reindex', reason: 'pruned' }
-  }
-
-  const anchor = (
-    await cli(subc, opts, 'getblockhash', String(anchorHeight))
-  ).trim()
-  await cli(subc, opts, 'invalidateblock', anchor)
-  // Verify the rollback actually disconnected the anchor. A tip still at or
-  // above the anchor is fine when the active chain no longer CONTAINS the
-  // invalidated anchor block — that means ActivateBestChain just connected
-  // a sibling branch (forking below the anchor) through full ConnectBlock
-  // validation under the active rules, which is a successful outcome. But
-  // if the anchor block itself is still in the active chain, the disconnect
-  // walk silently stopped at the prune horizon (pruning advanced between
-  // the gate check and the call): heal the partial rollback and fall back
-  // to reindex rather than reporting a re-validation that never happened.
-  const rolled = await cliJson<GetBlockchainInfo>(
-    subc,
-    opts,
-    'getblockchaininfo',
-  )
-  if (
-    rolled.blocks >= anchorHeight &&
-    (await cli(subc, opts, 'getblockhash', String(anchorHeight))).trim() ===
-      anchor
-  ) {
-    await cli(subc, opts, 'reconsiderblock', anchor)
-    return { outcome: 'requires-reindex', reason: 'pruned' }
-  }
-  // The pruned-race heal path is ruled out; the (possibly long) reconsider
-  // replay is about to begin. Fire onReplayStart here — not before
-  // invalidateblock — so a heal-path fallthrough cannot emit a "started"
-  // notification that never gets a matching "complete".
-  await onReplayStart?.()
-  try {
-    await cli(subc, opts, 'reconsiderblock', anchor)
-  } catch {
-    // The node is parked below the anchor with an invalid-marked chain.
-    // One retry; if it still fails the caller keeps the store flag set and
-    // the next start recovers through the parked-state path above.
-    await cli(subc, opts, 'reconsiderblock', anchor)
-  }
-  const after = await cliJson<GetBlockchainInfo>(
-    subc,
-    opts,
-    'getblockchaininfo',
-  )
-  return {
-    outcome: 'revalidated',
-    fromHeight: anchorHeight,
-    tipBefore: info.bestblockhash,
-    tipAfter: after.bestblockhash,
   }
 }

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -290,8 +290,8 @@ export const main = sdk.setupMain(async ({ effects }) => {
      * (BIP-110), so only the "leaving the enforcing flavor" half applies:
      * record the durable rdtsEnforcedLastRun=false marker each start and
      * clear invalid-block verdicts inherited from the RDTS-enforcing
-     * flavor. revalidateFromRdts stays dormant here — it is carried in the
-     * store shape for the enforcing flavor to consume after a switch back.
+     * flavor. The opposite direction needs nothing from the package — the
+     * enforcing flavor's own binary re-validates on arrival.
      * Runs once per start as soon as RPC answers; nothing depends on it, so
      * it never blocks the service.
      */


### PR DESCRIPTION
Bitcoin Knots >= `29.4.knots20260508` re-validates the RDTS-applicable block range itself when it starts on a datadir that advanced without enforcement. That is the only thing `revalidateAgainstRdts` existed for, and no flavor's package code calls it any more — so it comes out, along with `rdtsAnchorHeight`, `RDTS_FIRST_APPLICABLE_HEIGHT`, and the two store fields that only ever fed it (`revalidateFromRdts`, `rdtsReindexWarned`). Both were already dormant in this flavor: written by nothing, read by nothing.

**The leaving-enforcement half stays.** Clearing the RDTS verdicts a datadir inherits when someone switches to Bitcoin Core runs on a binary that has no concept of RDTS and cannot recognize those verdicts as foreign — no Knots release can close that direction. This flavor keeps writing the `rdtsEnforcedLastRun` marker each start, and keeps `reconsiderInvalidTips`.

`startos/forkRecovery.ts` is byte-identical across all six bitcoind flavor checkouts again (Core 28/29/30/31, Knots `29.x`, Knots `29.x-prerdts`). `isRdtsEnforcing` stays in it even though only the RDTS Knots flavor calls it — an export used by one consumer of a shared module isn't dead code, whereas `revalidateAgainstRdts` was dead in all six.

No behavior change, so no version bump. The README's "dormant flag" bullet and the `chain-recovery` docblock both described the removed machinery and have been corrected.

Companion PRs on the sibling base branches in this repo, and on `29.x-prerdts` in `bitcoin-knots-startos`. The RDTS Knots flavor (`29.x`) is handled separately in `Start9Labs/bitcoin-knots-startos#36`.

## Test plan

1. Build and install: `make x86 install`.
2. Start the service; confirm **RPC** reaches ready and **Blockchain Sync** reports progress.
3. Confirm the store no longer carries the removed fields and still records the marker: `cat /media/startos/data/package-data/volumes/bitcoind/data/main/store.json` — expect `rdtsEnforcedLastRun: false`, no `revalidateFromRdts`, no `rdtsReindexWarned`.
4. Sidegrade to Bitcoin Knots (`#knots`) and back. Confirm both switches complete and the `chain-recovery` oneshot runs without error in `start-cli package logs bitcoind` — on a chain with no invalid tips it is a silent no-op.
5. Run **Runtime Information** to confirm the action surface is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
